### PR TITLE
Updated default BLAS library, which IS necessary for creating the cache string.

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -3,7 +3,7 @@ set(PBSAM_LINKER_LIBS "")
 
 # ---[ BLAS
 if(NOT APPLE)
-  set(BLAS "MKL" CACHE STRING "Selected BLAS library")
+  set(BLAS "Open" CACHE STRING "Selected BLAS library")
   set_property(CACHE BLAS PROPERTY STRINGS "Atlas;Open;MKL")
 
   if(BLAS STREQUAL "Atlas" OR BLAS STREQUAL "atlas")

--- a/pbam/README.md
+++ b/pbam/README.md
@@ -15,8 +15,19 @@ cmake ..
 make pbam pbamtest
 ~~~
 
-This will make executables for pbam and pbamtest. Right now, the pbam 
+This will make executables for pbam and pbamtest. 
 Both executables can be found in the build subdirectory `bin/`
+
+If the user is building with macOS, then `vecLib` will be used to provide BLAS libraries.
+If the user is building on another system, the default `cmake` command assumes that OpenBLAS is installed on the user's system, and uses OpenBLAS to provide the BLAS libraries.  
+
+If you would like to instead  specify  either the MKL (Intel Math Kernel Library) or Atlas BLAS libraries when building on a non-macOS system, you can specify the `-DBLAS` flag when running the `cmake` command:
+
+`cmake -DBLAS="Atlas" ..` for Atlas BLAS libraries
+
+`cmake -DBLAS="MKL" ..` for MKL Blas libraries
+
+For information on installing the OpenBLas libraries, see http://www.openblas.net.
 
 ## Running
 

--- a/pbam/README.md
+++ b/pbam/README.md
@@ -25,9 +25,9 @@ If you would like to instead  specify  either the MKL (Intel Math Kernel Library
 
 `cmake -DBLAS="Atlas" ..` for Atlas BLAS libraries
 
-`cmake -DBLAS="MKL" ..` for MKL Blas libraries
+`cmake -DBLAS="MKL" ..` for MKL BLAS libraries
 
-For information on installing the OpenBLas libraries, see http://www.openblas.net.
+For information on installing the OpenBLAS libraries, see http://www.openblas.net.
 
 ## Running
 


### PR DESCRIPTION
It's small (a lot smaller than I thought this pull request was going to be, until I wrapped my mind around cache strings), but it should definitely make compiling on non-Macs a lot easier for people who try to compile and don't know the ins and outs of cmake and what the heck MKL is.

I think it's a safe assumption that many, many more people will have OpenBLAS, or at least can easily get a hold of it. I added description about specifying BLAS to PBAM's build section in the README.md, which, if you want to keep it, should probably be copied over to PBSAM's build section in the README.md as well. 

Anyway, you can pull this in if you want, but mainly look at it as notes on BLAS clarity for using PBAM/PBSAM on an non-Mac.